### PR TITLE
Bumped Siddhi Version to 4.0.0-alpha

### DIFF
--- a/component/src/test/java/org/wso2/extension/siddhi/map/text/sinkmapper/TextCustomSinkMapperTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/text/sinkmapper/TextCustomSinkMapperTestCase.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 import org.wso2.extension.siddhi.map.text.sinkmapper.util.HttpServerListenerHandler;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.exception.NoSuchAttributeException;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.sink.InMemorySink;
 import org.wso2.siddhi.core.util.SiddhiTestHelper;
@@ -427,7 +427,7 @@ public class TextCustomSinkMapperTestCase {
         InMemoryBroker.unsubscribe(subscriberIBM);
     }
 
-    @Test(expectedExceptions = NoSuchAttributeException.class)
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
     public void testTextSinkWrongMapping() throws InterruptedException {
         log.info("Test custom for wrong mapping.");
         List<Object> onMessageList = new ArrayList<Object>();

--- a/pom.xml
+++ b/pom.xml
@@ -147,10 +147,10 @@
     </build>
 
     <properties>
-        <siddhi.version>4.0.0-M114</siddhi.version>
-        <siddhi.extension.io.tcp.version>2.0.7</siddhi.extension.io.tcp.version>
-        <siddhi.extension.io.http.version>1.0.4</siddhi.extension.io.http.version>
-        <siddhi.extension.io.file.version>1.0.0-M10</siddhi.extension.io.file.version>
+        <siddhi.version>4.0.0-alpha</siddhi.version>
+        <siddhi.extension.io.tcp.version>2.0.8</siddhi.extension.io.tcp.version>
+        <siddhi.extension.io.http.version>1.0.6</siddhi.extension.io.http.version>
+        <siddhi.extension.io.file.version>1.0.0-M11</siddhi.extension.io.file.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <testng.version>6.11</testng.version>


### PR DESCRIPTION
## Purpose
> Release the extension with the latest siddhi version.

## Goals
> Bumped Siddhi Version to 4.0.0-alpha and fixing test cases with Siddhi Api.